### PR TITLE
Add char16_t to copy and grant types

### DIFF
--- a/code/include/rlbox_stdlib.hpp
+++ b/code/include/rlbox_stdlib.hpp
@@ -137,7 +137,8 @@ inline T_Wrap<T_Rhs*, T_Sbx> memset(rlbox_sandbox<T_Sbx>& sandbox,
 template<typename T>
 static constexpr bool can_type_be_memcopied =
   std::is_same_v<char, std::remove_cv_t<T>> || std::is_same_v<wchar_t, std::remove_cv_t<T>> ||
-  std::is_same_v<float, std::remove_cv_t<T>> || std::is_same_v<double, std::remove_cv_t<T>>;
+  std::is_same_v<float, std::remove_cv_t<T>> || std::is_same_v<double, std::remove_cv_t<T>> ||
+  std::is_same_v<char16_t, std::remove_cv_t<T>>;
 
 /**
  * @brief Copy to sandbox memory area. Note that memcpy is meant to be called on


### PR DESCRIPTION
This PR fixes a build error in Firefox.