### PR TITLE
Reduce dependency to <iostream> in header

### DIFF
--- a/code/include/rlbox_helpers.hpp
+++ b/code/include/rlbox_helpers.hpp
@@ -3,7 +3,7 @@
 // IWYU pragma: friend "rlbox_.*\.hpp"
 
 #include <cstdlib>
-#include <iostream>
+#include <cstdio>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
@@ -27,7 +27,7 @@ namespace detail {
       #ifdef RLBOX_CUSTOM_ABORT
         RLBOX_CUSTOM_ABORT(msg);
       #else
-        std::cerr << msg << std::endl;
+        fprintf(stderr, "%s\n", msg);
         std::abort();
       #endif
     #endif
@@ -65,11 +65,11 @@ namespace detail {
   void printTypes()
   {
 #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
-    std::cout << __PRETTY_FUNCTION__ << std::endl; // NOLINT
+    puts(__PRETTY_FUNCTION__); // NOLINT
 #elif defined(_MSC_VER)
-    std::cout << __FUNCSIG__ << std::endl; // NOLINT
+    puts(__FUNCSIG__); // NOLINT
 #else
-    std::cout << "Unsupported" << std::endl;
+    puts("Unsupported");
 #endif
   }
 


### PR DESCRIPTION
<iostream> comes with global constructors (to initialize std::cout, std::cerr and the likes) and is a rather large header on its own. Having it in a header impacts all compilation unit that include this header.

Use <cstdio> instead for the simple formatting used in rlbox_helpers.hpp.